### PR TITLE
Round Result Page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    domains: ["raw.githubusercontent.com"],
+  },
 };
 
 export default nextConfig;

--- a/src/app/solo/game-settings/page.tsx
+++ b/src/app/solo/game-settings/page.tsx
@@ -8,6 +8,7 @@ import Popup from "@/components/ui/popup";
 import { FILTERS } from "@/data/filterOptions";
 import { HOW_TO_PLAY } from "@/data/instructions";
 import { useGameContext } from "@/context/gameContext";
+import { overwriteStoredPokemon } from "@/utils/pokemon";
 
 export default function VersusSettings() {
   const router = useRouter();
@@ -171,11 +172,14 @@ export default function VersusSettings() {
         </Button>
         <Button
           color="primary"
-          onClick={() =>
-            isEmpty(dropdownValues)
-              ? setIsErrorPopupOpen(true)
-              : router.push("/solo/game/1/")
-          }
+          onClick={() => {
+            if (isEmpty(dropdownValues)) {
+              setIsErrorPopupOpen(true);
+            } else {
+              overwriteStoredPokemon();
+              router.push("/solo/game/1/");
+            }
+          }}
         >
           Start Game
         </Button>

--- a/src/app/solo/game/[round]/result/page.tsx
+++ b/src/app/solo/game/[round]/result/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+import "@/styles/globals.css";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import Button from "@/components/ui/button";
+import Popup from "@/components/ui/popup";
+import { useGameContext } from "@/context/gameContext";
+import { overwriteStoredPokemon } from "@/utils/pokemon";
+
+export default function GameRoundResult() {
+  const router = useRouter();
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  let pokemon = null;
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem("currentPokemon");
+    if (stored) pokemon = JSON.parse(stored);
+  }
+
+  const { isCanvasOn, isRoundsOn, numRounds, reset, currRound, setCurrRound } =
+    useGameContext();
+
+  const isFinalRound = isRoundsOn && currRound === numRounds;
+
+  function getImageUrl(apiUrl: string) {
+    const match = apiUrl.match(/\/pokemon\/(\d+)\//);
+    const id = match ? match[1] : "1";
+    return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png`;
+  }
+
+  function handleNextRound() {
+    if (!isRoundsOn || currRound < numRounds) {
+      setCurrRound((prev) => {
+        const next = prev + 1;
+        return next;
+      });
+      overwriteStoredPokemon();
+      router.push(`/solo/game/${currRound + 1}`);
+    } else {
+      router.push("solo/game-results");
+    }
+  }
+
+  return (
+    <div className="flex flex-col flex-grow justify-between h-full w-full">
+      <Popup
+        open={isPopupOpen}
+        onClose={() => setIsPopupOpen(false)}
+        label="Are you sure you want to end the game?"
+        buttonLabelLeft="Cancel"
+        onClickLeft={() => setIsPopupOpen(false)}
+        buttonLabelRight="OK"
+        onClickRight={() => {
+          reset();
+          setCurrRound(0);
+          router.push("/solo/game-results");
+        }}
+      />
+      {!isCanvasOn && <div />}
+      <div className="flex flex-col items-center gap-4">
+        <div className="flex gap-6 items-center">
+          <h1 className="font-title text-6xl">
+            {hasMounted ? pokemon.name.toUpperCase() : "LOADING..."}
+          </h1>
+        </div>
+        <div className="flex items-center">
+          <div className="shrink-0">
+            {hasMounted && pokemon ? (
+              <Image
+                src={getImageUrl(pokemon.url)}
+                alt={pokemon.name}
+                width={300}
+                height={300}
+              />
+            ) : (
+              <p>Loading Pokémon...</p>
+            )}
+          </div>
+          {isCanvasOn && <div className="w-90 h-100 bg-white" />}
+        </div>
+        <div className="flex gap-4">
+          <Button color="tertiary" size="small" disabled={true}>
+            Save to Gallery
+          </Button>
+          <Button color="secondary" size="small" onClick={handleNextRound}>
+            {isFinalRound ? "End Game" : "Next Round"}
+          </Button>
+        </div>
+      </div>
+      <footer className="flex justify-between items-center p-4">
+        <div className="font-title text-3xl">
+          Round: {currRound} {isFinalRound && "(FINAL ROUND)"}
+        </div>
+        <Button
+          color="primary"
+          onClick={() => {
+            if (isFinalRound) {
+              handleNextRound();
+            } else {
+              setIsPopupOpen(true);
+            }
+          }}
+        >
+          End Game
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/src/context/gameContext.tsx
+++ b/src/context/gameContext.tsx
@@ -39,7 +39,7 @@ type GameContextType = {
   setFormValue: (val: string[]) => void;
   reset: () => void;
   currRound: number;
-  setCurrRound: (val: number) => void;
+  setCurrRound: Dispatch<SetStateAction<number>>;
   skipsLeft: number;
   setSkipsLeft: Dispatch<SetStateAction<number>>;
 };

--- a/src/utils/pokemon.ts
+++ b/src/utils/pokemon.ts
@@ -1,0 +1,34 @@
+export type Pokemon = { name: string; url: string };
+
+/** Fetch one random Pokémon from the public PokéAPI */
+export async function fetchRandomPokemon(): Promise<Pokemon> {
+  const res = await fetch("https://pokeapi.co/api/v2/pokemon?limit=1000");
+  if (!res.ok) throw new Error("Failed to fetch Pokémon list");
+
+  const data: { results: Pokemon[] } = await res.json();
+  return data.results[Math.floor(Math.random() * data.results.length)];
+}
+
+/**
+ * Return the Pokémon saved in localStorage (if present) or
+ * fetch a new random one and persist it under "currentPokemon".
+ */
+export async function loadOrFetchPokemon(): Promise<Pokemon> {
+  const stored =
+    typeof window !== "undefined"
+      ? localStorage.getItem("currentPokemon")
+      : null;
+
+  if (stored) return JSON.parse(stored) as Pokemon;
+
+  return overwriteStoredPokemon(); // fall through to fresh fetch / save
+}
+
+/** Always fetch a fresh Pokémon and overwrite "currentPokemon" in localStorage */
+export async function overwriteStoredPokemon(): Promise<Pokemon> {
+  const pokemon = await fetchRandomPokemon();
+  if (typeof window !== "undefined") {
+    localStorage.setItem("currentPokemon", JSON.stringify(pokemon));
+  }
+  return pokemon;
+}


### PR DESCRIPTION
# Pull Request

## Description

Completed the Round Result page which includes the placeholder for the user's drawer, displaying the pokemon sprite, and round logic (allowing the user to play through all the rounds).

## What Was Done

- Configured the images domain in `next.config.ts`
- Moved the pokemon API logic into a util file called `pokemon.ts`
- Changed the pokemon generation logic to now be handled only by the start game , skip, and next round buttons to prevent changing the pokemon on refresh page (`overwriteStoredPokemon`)
- Added final round logic to display a message when it's the final round and ends the game when the final round it reached
  - Made sure that final round logic doesn't occur when `isRoundsOn` is false

## Screenshots (if applicable)
![SketchThatMon (Round Results)](https://github.com/user-attachments/assets/d6e0e854-6ecd-4824-bbbf-b34e4eb32ddd)

## Related Issues

Closes #10 

## ✅ Checklist

- [x] Code is well-organized and follows project structure
- [x] Components are reusable where appropriate
- [x] No console errors or warnings
- [x] Lint and format checks pass
- [x] App builds and runs successfully